### PR TITLE
Support absolute path to nixpkgs checkout

### DIFF
--- a/app-shell.bash
+++ b/app-shell.bash
@@ -7,7 +7,7 @@ script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 
 usage() {
   cat <<EOF
-Usage: $(basename "${BASH_SOURCE[0]}") [options] -- [command]
+Usage: app-shell [options] -- [command]
 
 Create a temporary shell environment containing specified applications.
 

--- a/app-shell.bash
+++ b/app-shell.bash
@@ -13,11 +13,12 @@ Create a temporary shell environment containing specified applications.
 
 Available options:
 
--n, --nixpkgs         Nixpkgs tarball to use.
+-n, --nixpkgs         Nixpkgs tarball to use, or an absolute path to a nixpkgs checkout.
                       Default:
                         https://github.com/NixOS/nixpkgs/archive/nixos-unstable.tar.gz
-                      Example:
+                      Examples:
                         https://github.com/NixOS/nixpkgs/archive/nixos-24.11.tar.gz
+                        /home/user/dev/my-nixpkgs
 
 -a, --apps            Comma separated list of applications to enable on PATH.
                       Example: gdal,qgis

--- a/app-shell.nix
+++ b/app-shell.nix
@@ -14,7 +14,8 @@
 }:
 
 let
-  pkgs = import (fetchTarball nixpkgs) { };
+  nixpkgsFetched = if (builtins.substring 0 1 nixpkgs) == "/" then nixpkgs else (fetchTarball nixpkgs);
+  pkgs = import nixpkgsFetched { };
 
   inherit (pkgs)
     writeShellScript


### PR DESCRIPTION
I have a local nixpkgs checkout that I like to use for most purposes. The first commit adds support for passing an absolute path to `--nixpkgs`.

The second commit fixes a minor issue in the help output, where it says `.app-shell-wrapped` instead of the proper program name.