### PR TITLE
use shell from `SHELL` variable

### DIFF
--- a/app-shell.nix
+++ b/app-shell.nix
@@ -95,7 +95,7 @@ let
     ${libraryPath}
     ${includePath}
 
-    ${pkgs.lib.getExe pkgs.bash} --norc ${runCommand}
+    ''${SHELL:-${pkgs.lib.getExe pkgs.bash} --norc} ${runCommand}
   '';
 
 in


### PR DESCRIPTION
picks a shell based on the `SHELL` variable before falling back to bash.

closes #3.
